### PR TITLE
clarify Python compatible versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SpinQit is the quantum software development kit from SpinQ Technology Co., Ltd.
 ## Installation and Documentation
 
 - SpinQit is available on Windows, Linux and MacOS. Only the **Windows** version can use a local quantum computer as a backend. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
-- SpinQit requires Python 3.8+.  This package has been tested with Python 3.8.13 and 3.9.12.
+- SpinQit requires Python 3.8 or Python 3.9.  This package has been tested with Python 3.8.13 and 3.9.12.
 - We suggest you use Anaconda to set up your Python environment.
 
 SpinQit can be installed using the following command:

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 - SpinQit is available on Windows, Linux and MacOS. Only the **Windows** version can use a local quantum computer as a backend. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
-- SpinQit requires Python 3.8+.  This package has been tested with Python 3.8.13 and 3.9.12.
+- SpinQit requires Python 3.8 or Python 3.9. This package has been tested with Python 3.8.13 and 3.9.12.
 - We suggest you use Anaconda to set up your Python environment. Please refer to [https://docs.anaconda.com/anaconda/](https://docs.anaconda.com/anaconda/) about how to install and use a conda environment. On Windows, we recommend adding Anaconda to your PATH environment viarable to avoid unnecessary troubles.
 ## Installation
 SpinQit can be installed using the following command:

--- a/setup.py
+++ b/setup.py
@@ -112,14 +112,15 @@ setup(
     packages=find_packages(),
     classifiers=[
         'Development Status :: 4 - Beta',
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS"
     ],
     ext_modules=[CMakeExtension('spinqit.spinq_backends')],
     install_requires=['numpy<2.0.0', 'scipy', 'scikit-learn', 'torch', 'autograd==1.5.0', 'psutil', 'retworkx', 'python-igraph==0.9.10', 'pybind11', 'antlr4-python3-runtime==4.9.2', 'python-constraint', 'requests', 'matplotlib>=3.5', 'pycryptodome==3.11.0', 'autoray==0.6.1', 'noisyopt==0.2.2', 'sympy'],
-    python_requires='>=3.8',
+    python_requires=">=3.8, <3.10",
     cmdclass=dict(build_ext=CMakeBuild),
     package_data={'spinqit': package_data_files},
     data_files=date_files_list,


### PR DESCRIPTION
- clarify that spinqit is only compatible with Python 3.8 and 3.9
- this fixes #6 