### PR TITLE
Mac can use local quantum computer as a backend too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SpinQit is the quantum software development kit from SpinQ Technology Co., Ltd.
 
 ## Installation and Documentation
 
-- SpinQit is available on Windows, Linux and MacOS. Only the **Windows** version can use a local quantum computer as a backend. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
+- SpinQit is available on Windows, Linux and MacOS. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
 - SpinQit requires Python 3.8+.  This package has been tested with Python 3.8.13 and 3.9.12.
 - We suggest you use Anaconda to set up your Python environment.
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -1,7 +1,7 @@
 # Basics
 ## Requirements
 
-- SpinQit is available on Windows, Linux and MacOS. Only the **Windows** version can use a local quantum computer as a backend. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
+- SpinQit is available on Windows, Linux and MacOS. This package has been tested on Ubuntu 20.04 & 22.04 (x86_64), Windows 10 (x86_64), MacOS Ventura 13.0 (M1, M2) and MacOS Mojave 10.14.6 (x86_64).
 - SpinQit requires Python 3.8+.  This package has been tested with Python 3.8.13 and 3.9.12.
 - We suggest you use Anaconda to set up your Python environment. Please refer to [https://docs.anaconda.com/anaconda/](https://docs.anaconda.com/anaconda/) about how to install and use a conda environment. On Windows, we recommend adding Anaconda to your PATH environment viarable to avoid unnecessary troubles.
 ## Installation


### PR DESCRIPTION
- as of v0.2.4 both Windows and Mac can use local quantum computer as a backend
- this fixes #8 